### PR TITLE
Add some basic branch protection rules to LSP4MP default branch.

### DIFF
--- a/otterdog/eclipse-lsp4mp.jsonnet
+++ b/otterdog/eclipse-lsp4mp.jsonnet
@@ -36,6 +36,16 @@ orgs.newOrg('technology.lsp4mp', 'eclipse-lsp4mp') {
           ],
         },
       ],
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main') {
+          "allows_deletions": false,
+          "allows_force_pushes": false,
+          required_approving_review_count: null,
+          requires_pull_request: false,
+          requires_status_checks: false,
+          requires_strict_status_checks: true,
+        },
+      ],
     },
   ],
 } + {


### PR DESCRIPTION
I noticed on https://otterdog.eclipse.org/projects/technology.lsp4mp#repositories that lsp4mp lacks any branch protection rules (at least for main).

CC'ing @datho7561 for awareness.